### PR TITLE
System specific new-line symbol replaced with System indended.

### DIFF
--- a/src/test/java/com/pluralsight/blog/Module2_Tests.java
+++ b/src/test/java/com/pluralsight/blog/Module2_Tests.java
@@ -205,7 +205,7 @@ public class Module2_Tests {
         try {
             final String output = "";
             List<String> allLines = Files.readAllLines(path);
-            result = String.join("\n", allLines);
+            result = String.join(System.lineSeparator(), allLines);
         } catch (IOException e) {
             //e.printStackTrace();
         }


### PR DESCRIPTION
The test fails on Windows machines but runs fine on Linux.

I have replaced the system depended symbol with a standard system call to resolve the issue.
